### PR TITLE
Couldn't select search results and other bugs

### DIFF
--- a/core.js
+++ b/core.js
@@ -10,7 +10,6 @@ var KEY_ARROW_RIGHT = 39;
 var KEY_ARROW_LEFT = 37;
 var KEY_ARROW_UP = 38;
 var KEY_SPECIAL_ENTER = 13;
-var KEY_SPECIAL_SPACE = 32;
 
 document.onkeydown = function (e) {
 
@@ -21,15 +20,16 @@ document.onkeydown = function (e) {
         //find all search results
         var eles = $("li.g");
         var elementsCount = eles.length;
+        var NEW_TAB = event.metaKey
 
-        if (e.keyCode == KEY_SPECIAL_ENTER && selectedUrl != STRING_EMPTY) {
+        if (e.keyCode == KEY_SPECIAL_ENTER && NEW_TAB == false && selectedUrl != STRING_EMPTY) {
 
             //shift + enter = go to highlighted
             window.location = selectedUrl;
 
-        } else if (e.keyCode == KEY_SPECIAL_SPACE && selectedUrl != STRING_EMPTY) {
+        } else if (e.keyCode == KEY_SPECIAL_ENTER && NEW_TAB == true && selectedUrl != STRING_EMPTY) {
 
-            //shift + space = go to highlighted in new tab
+            //ctrl + shift + enter = go to highlighted in new tab
             window.open(selectedUrl);
 
         } else if (e.keyCode == KEY_ARROW_RIGHT && selectedUrl != STRING_EMPTY) {

--- a/core.js
+++ b/core.js
@@ -20,7 +20,13 @@ document.onkeydown = function (e) {
         //find all search results
         var eles = $(".g");
         var elementsCount = eles.length;
-        var NEW_TAB = event.metaKey
+
+        //determine if ctrl key is down (command key on Mac)
+        if (navigator.appVersion.indexOf("Mac") !=- 1) {
+            var NEW_TAB = event.metaKey; //true if OS is Mac and command key is down
+        } else {
+            var NEW_TAB = event.ctrlKey; //true if OS is not Mac and ctrl key is down
+        }
 
         if (e.keyCode == KEY_SPECIAL_ENTER && NEW_TAB == false && selectedUrl != STRING_EMPTY) {
 

--- a/core.js
+++ b/core.js
@@ -18,7 +18,7 @@ document.onkeydown = function (e) {
     if (e.shiftKey) {
 
         //find all search results
-        var eles = $("li.g");
+        var eles = $(".g");
         var elementsCount = eles.length;
         var NEW_TAB = event.metaKey
 

--- a/core.js
+++ b/core.js
@@ -32,12 +32,12 @@ document.onkeydown = function (e) {
             //shift + space = go to highlighted in new tab
             window.open(selectedUrl);
 
-        } else if (e.keyCode == KEY_ARROW_RIGHT) {
+        } else if (e.keyCode == KEY_ARROW_RIGHT && selectedUrl != STRING_EMPTY) {
 
             //go to next page
             window.location = $(".navend:last a").attr("href");
 
-        } else if (e.keyCode == KEY_ARROW_LEFT) {
+        } else if (e.keyCode == KEY_ARROW_LEFT && selectedUrl != STRING_EMPTY) {
 
             //go to previous page
             if ($("td.cur").text()!=1) //if we are on the first page, we can't go back

--- a/popup.html
+++ b/popup.html
@@ -12,7 +12,7 @@
 	<br />
 	SHIFT + ENTER = navigates to selected website (when item is highlighted)
 	<br />
-	SHIFT + SPACE = opens new tab to selected website (when item is highlighted)
+	CTRL + SHIFT + ENTER = opens new tab to selected website (when item is highlighted)
 	<br />
 	SHIFT + ARROW RIGHT = move to next page
 	<br />


### PR DESCRIPTION
Google may have changed the way its results are displayed, breaking this program. The jQuery command "li.g" was changed to just ".g" to fix this. Also changed was the shortcut to open a new tab. The previous shortcut, shift+space, opened a new window on some browsers. Using ctrl (command on Mac) in the new tab shortcut opens a new tab instead of a window, as that is the key normally used to open a new tab.
